### PR TITLE
Allow toggling individual images

### DIFF
--- a/app/src/main/java/com/chiller3/msd/settings/DeviceInfo.kt
+++ b/app/src/main/java/com/chiller3/msd/settings/DeviceInfo.kt
@@ -22,16 +22,19 @@ enum class DeviceType : Parcelable {
 data class DeviceInfo(
     val uri: Uri,
     val type: DeviceType,
+    val enabled: Boolean,
 ) : Parcelable {
     companion object {
         private val TAG = DeviceInfo::class.java.simpleName
 
         private const val PREF_SUFFIX_URI = "uri"
         private const val PREF_SUFFIX_TYPE = "type"
+        private const val PREF_SUFFIX_ENABLED = "enabled"
 
         fun fromRawPreferences(prefs: SharedPreferences, prefix: String): DeviceInfo? {
             val rawUri = prefs.getString(prefix + PREF_SUFFIX_URI, null) ?: return null
             val rawType = prefs.getString(prefix + PREF_SUFFIX_TYPE, null) ?: return null
+            val enabled = prefs.getBoolean(prefix + PREF_SUFFIX_ENABLED, true)
 
             val uri = Uri.parse(rawUri)
             val type = try {
@@ -41,12 +44,13 @@ data class DeviceInfo(
                 return null
             }
 
-            return DeviceInfo(uri, type)
+            return DeviceInfo(uri, type, enabled)
         }
     }
 
     fun toRawPreferences(editor: SharedPreferences.Editor, prefix: String) {
         editor.putString(prefix + PREF_SUFFIX_URI, uri.toString())
         editor.putString(prefix + PREF_SUFFIX_TYPE, type.toString())
+        editor.putBoolean(prefix + PREF_SUFFIX_ENABLED, enabled)
     }
 }

--- a/app/src/main/java/com/chiller3/msd/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/chiller3/msd/settings/SettingsViewModel.kt
@@ -131,9 +131,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 val index = newDevices.indexOfFirst { it.uri == uri }
 
                 if (index >= 0) {
-                    newDevices[index] = DeviceInfo(uri, deviceType)
+                    newDevices[index] = newDevices[index].copy(type = deviceType)
                 } else {
-                    newDevices.add(DeviceInfo(uri, deviceType))
+                    newDevices.add(DeviceInfo(uri, deviceType, true))
 
                     // Only local files will ever work. Even if a SAF provider provides a regular
                     // file via a FUSE mount with StorageManager.openProxyFileDescriptor(), it won't
@@ -216,6 +216,17 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         refreshDevices()
     }
 
+    fun toggleDevice(uri: Uri, enabled: Boolean) {
+        prefs.devices = devices.value.map {
+            if (it.uri == uri) {
+                it.copy(enabled = enabled)
+            } else {
+                it
+            }
+        }
+        refreshDevices()
+    }
+
     private fun setMassStorage(newDevices: List<DeviceInfo>) {
         viewModelScope.launch {
             withLockedUi {
@@ -241,7 +252,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     }
 
     fun enableMassStorage() {
-        setMassStorage(prefs.devices)
+        setMassStorage(prefs.devices.filter { it.enabled })
     }
 
     fun disableMassStorage() {

--- a/app/src/main/java/com/chiller3/msd/view/SplitSwitchPreference.kt
+++ b/app/src/main/java/com/chiller3/msd/view/SplitSwitchPreference.kt
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.msd.view
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.PreferenceViewHolder
+import androidx.preference.SwitchPreferenceCompat
+import com.chiller3.msd.R
+
+/**
+ * A switch preference with a divider between the main preference and the switch. It is both
+ * clickable and switchable.
+ */
+class SplitSwitchPreference : SwitchPreferenceCompat {
+    @Suppress("unused")
+    constructor(context: Context) : this(context, null)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?) :
+            this(context, attrs, R.attr.splitSwitchPreferenceStyle)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
+            this(context, attrs, defStyleAttr, 0)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) :
+            super(context, attrs, defStyleAttr, defStyleRes)
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        val switchView = holder.findViewById(androidx.preference.R.id.switchWidget)
+
+        // Perform the toggling only when clicking the switch itself.
+        switchView.isClickable = true
+    }
+
+    override fun onClick() {
+        // Don't toggle the switch when clicking the main preference area.
+    }
+}

--- a/app/src/main/res/layout/material_switch_preference.xml
+++ b/app/src/main/res/layout/material_switch_preference.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<!-- The ID must match the androidx preference library. -->
+<com.google.android.material.materialswitch.MaterialSwitch
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/switchWidget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:focusable="false"
+    android:clickable="false"
+    android:background="@null" />

--- a/app/src/main/res/layout/split_switch_preference.xml
+++ b/app/src/main/res/layout/split_switch_preference.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:gravity="end|center_vertical"
+    android:orientation="horizontal"
+    android:paddingTop="16dp"
+    android:paddingBottom="16dp">
+    <View
+        android:layout_width="1dp"
+        android:layout_height="32dp"
+        android:layout_marginStart="?android:attr/listPreferredItemPaddingStart"
+        android:layout_marginEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:background="?android:attr/listDivider" />
+
+    <include layout="@layout/material_switch_preference" />
+</LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<resources>
+    <declare-styleable name="SplitSwitchPreference">
+        <attr name="splitSwitchPreferenceStyle" format="reference" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<resources>
+    <style name="SwitchPreferenceCompat.Material3" parent="Preference.SwitchPreferenceCompat.Material">
+        <item name="android:widgetLayout">@layout/material_switch_preference</item>
+    </style>
+
+    <style name="SplitSwitchPreference.Material3" parent="Preference.SwitchPreferenceCompat.Material">
+        <item name="android:widgetLayout">@layout/split_switch_preference</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <resources>
@@ -9,5 +9,7 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
         <item name="windowActionModeOverlay">true</item>
+        <item name="switchPreferenceCompatStyle">@style/SwitchPreferenceCompat.Material3</item>
+        <item name="splitSwitchPreferenceStyle">@style/SplitSwitchPreference.Material3</item>
     </style>
 </resources>


### PR DESCRIPTION
This way, users don't need to remove and re-add images when they only want a certain subset of them to be active at the moment.