### PR TITLE
Make UI less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ MSD does not need to run in the background. Once configured, the mass storage de
 
 The Android app part of MSD does not use any permissions at all. Also, despite that it is installed as a system app, the SELinux policy is configured so that it is not granted any more privileges than a regular user app.
 
-The daemon part of MSD runs as the `system` user and with the `CAP_CHOWN` capability allowed. The daemon is responsible for all USB configuration. It accepts 2 requests from the app:
+The daemon part of MSD runs as the `system` user and with the `CAP_CHOWN` capability allowed. The daemon is responsible for all USB configuration. It accepts 3 requests from the app:
 
 * Query the currently active USB gadget functions
 * Set up mass storage devices from a list of file descriptors
+* Query the currently active mass storage devices
 
 When setting up mass storage devices, the daemon never opens files on its own. The app opens files itself and then sends the open file descriptor the daemon over a Unix socket. This way, even if a malicious client happened to be able to connect to the daemon, it can't expose files over mass storage devices that it didn't already have access to.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ MSD is installed as a Magisk/KernelSU module so that it can run with system app 
 
 4. Add one or more CD-ROM/disk images.
 
-5. Enable the mass storage function.
+5. Apply the settings.
 
 6. That's it!
 

--- a/app/src/main/java/com/chiller3/msd/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/msd/MainApplication.kt
@@ -35,6 +35,8 @@ class MainApplication : Application() {
 
         // Enable Material You colors
         DynamicColors.applyToActivitiesIfAvailable(this)
+
+        Preferences(this).migrationRemoveEnableState()
     }
 
     companion object {

--- a/app/src/main/java/com/chiller3/msd/Preferences.kt
+++ b/app/src/main/java/com/chiller3/msd/Preferences.kt
@@ -18,8 +18,7 @@ class Preferences(context: Context) {
         const val PREF_ADD_DEVICE = "add_device"
         const val PREF_DEVICE_PREFIX = "device_"
         const val PREF_ACTIVE_FUNCTIONS = "active_functions"
-        const val PREF_ENABLE_MASS_STORAGE = "enable_mass_storage"
-        const val PREF_DISABLE_MASS_STORAGE = "disable_mass_storage"
+        const val PREF_APPLY_SETTINGS = "apply_settings"
 
         const val PREF_VERSION = "version"
         const val PREF_OPEN_LOG_DIR = "open_log_dir"
@@ -54,4 +53,14 @@ class Preferences(context: Context) {
     var isDebugMode: Boolean
         get() = prefs.getBoolean(PREF_DEBUG_MODE, false)
         set(enabled) = prefs.edit { putBoolean(PREF_DEBUG_MODE, enabled) }
+
+    /** Remove persistent per-device enable state from version <= 1.3. */
+    fun migrationRemoveEnableState() = prefs.edit {
+        val keys = prefs.all.keys.filter {
+            it.startsWith(PREF_DEVICE_PREFIX) && it.endsWith("_enabled")
+        }
+        for (key in keys) {
+            remove(key)
+        }
+    }
 }

--- a/app/src/main/java/com/chiller3/msd/daemon/Client.kt
+++ b/app/src/main/java/com/chiller3/msd/daemon/Client.kt
@@ -100,7 +100,7 @@ class Client : Closeable {
                     DeviceType.DISK_RW
                 }
 
-                DeviceInfo(Uri.fromFile(File(it.file)), type, true)
+                DeviceInfo(Uri.fromFile(File(it.file)), type)
             }
             else -> throw IOException("Invalid response: ${response.message}")
         }

--- a/app/src/main/java/com/chiller3/msd/settings/DeviceInfo.kt
+++ b/app/src/main/java/com/chiller3/msd/settings/DeviceInfo.kt
@@ -22,19 +22,16 @@ enum class DeviceType : Parcelable {
 data class DeviceInfo(
     val uri: Uri,
     val type: DeviceType,
-    val enabled: Boolean,
 ) : Parcelable {
     companion object {
         private val TAG = DeviceInfo::class.java.simpleName
 
         private const val PREF_SUFFIX_URI = "uri"
         private const val PREF_SUFFIX_TYPE = "type"
-        private const val PREF_SUFFIX_ENABLED = "enabled"
 
         fun fromRawPreferences(prefs: SharedPreferences, prefix: String): DeviceInfo? {
             val rawUri = prefs.getString(prefix + PREF_SUFFIX_URI, null) ?: return null
             val rawType = prefs.getString(prefix + PREF_SUFFIX_TYPE, null) ?: return null
-            val enabled = prefs.getBoolean(prefix + PREF_SUFFIX_ENABLED, true)
 
             val uri = Uri.parse(rawUri)
             val type = try {
@@ -44,13 +41,12 @@ data class DeviceInfo(
                 return null
             }
 
-            return DeviceInfo(uri, type, enabled)
+            return DeviceInfo(uri, type)
         }
     }
 
     fun toRawPreferences(editor: SharedPreferences.Editor, prefix: String) {
         editor.putString(prefix + PREF_SUFFIX_URI, uri.toString())
         editor.putString(prefix + PREF_SUFFIX_TYPE, type.toString())
-        editor.putBoolean(prefix + PREF_SUFFIX_ENABLED, enabled)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,10 +20,8 @@
     <!-- USB preferences -->
     <string name="pref_active_functions_name">Active USB gadget functions</string>
     <string name="pref_active_functions_desc_none">(No active functions. Press to refresh.)</string>
-    <string name="pref_enable_mass_storage_name">Enable mass storage function</string>
-    <string name="pref_enable_mass_storage_desc">Enable emulating the specified mass storage devices.</string>
-    <string name="pref_disable_mass_storage_name">Disable mass storage function</string>
-    <string name="pref_disable_mass_storage_desc">Remove all emulated mass storage devices.</string>
+    <string name="pref_enable_mass_storage_name">Apply settings</string>
+    <string name="pref_enable_mass_storage_desc">Enable or disable emulating the specified mass storage devices.</string>
 
     <!-- About "preference" -->
     <string name="pref_version_name">Version</string>
@@ -34,9 +32,9 @@
 
     <!-- Alerts -->
     <string name="action_details">Details</string>
-    <string name="alert_get_functions_failure">Failed to get list of active USB gadget functions.</string>
-    <string name="alert_set_mass_storage_failure">Failed to configure mass storage device emulation.</string>
-    <string name="alert_reenable_required">The changes will take effect the next time the mass storage function is enabled.</string>
+    <string name="alert_query_state_failure">Failed to query USB controller state.</string>
+    <string name="alert_apply_state_failure">Failed to configure USB controller.</string>
+    <string name="alert_reapply_required">The changes will take effect the next time the settings are applied.</string>
     <string name="alert_not_local_file">Failed to add image because it is not a local file.</string>
     <string name="alert_not_local_file_details">The image could not be added because it is not a local file. Even if the third party app goes through the effort to provide a file descriptor supporting random access, Android\'s limitations on reopening files prevents it from being used.</string>
     <string name="alert_create_image_failure">Failed to create new writable disk image.</string>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -28,17 +28,10 @@
             app:iconSpaceReserved="false" />
 
         <Preference
-            app:key="enable_mass_storage"
+            app:key="apply_settings"
             app:persistent="false"
             app:title="@string/pref_enable_mass_storage_name"
             app:summary="@string/pref_enable_mass_storage_desc"
-            app:iconSpaceReserved="false" />
-
-        <Preference
-            app:key="disable_mass_storage"
-            app:persistent="false"
-            app:title="@string/pref_disable_mass_storage_name"
-            app:summary="@string/pref_disable_mass_storage_desc"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 

--- a/msd-tool/src/sepatch.rs
+++ b/msd-tool/src/sepatch.rs
@@ -325,7 +325,14 @@ pub fn subcommand_sepatch(cli: &SepatchCli) -> Result<()> {
     ] {
         pdb.set_rule(t_daemon, t_configfs, c_dir, perm, RuleAction::Allow);
     }
-    for perm in [p_file_create, p_file_open, p_file_setattr, p_file_write] {
+    for perm in [
+        p_file_create,
+        p_file_getattr,
+        p_file_open,
+        p_file_read,
+        p_file_setattr,
+        p_file_write,
+    ] {
         pdb.set_rule(t_daemon, t_configfs, c_file, perm, RuleAction::Allow);
     }
     for perm in [p_lnk_file_create, p_lnk_file_read, p_lnk_file_unlink] {


### PR DESCRIPTION
The initial state of the UI now reflects what's actually active in the kernel. All active devices will have switches in the on state initially. To allow this repurposing of the on/off switch, the on/off state is no longer persisted. That was not really a useful feature and served no purpose.

The enable and disable options have also been combined into a single "apply settings" option.