### PR TITLE
Add additional logging to boot scripts

### DIFF
--- a/app/module/boot_common.sh
+++ b/app/module/boot_common.sh
@@ -4,6 +4,9 @@
 
 # source "${0%/*}/boot_common.sh" <log file>
 
+log_dir=$(dirname "${1}")
+mkdir -p "${log_dir}"
+
 exec >"${1}" 2>&1
 
 mod_dir=${0%/*}

--- a/app/module/post-fs-data.sh
+++ b/app/module/post-fs-data.sh
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
 # SPDX-License-Identifier: GPL-3.0-only
 
-source "${0%/*}/boot_common.sh" /data/local/tmp/msd.post-fs-data.log
+source "${0%/*}/boot_common.sh" /data/local/tmp/msd/post-fs-data.log
 
 # toybox's `mountpoint` command only works for directories, but bind mounts can
 # be files too.
@@ -15,7 +15,9 @@ has_mountpoint() {
 
 header Patching SELinux policy
 
+cp /sys/fs/selinux/policy "${log_dir}"/sepolicy.orig
 "${mod_dir}"/msd-tool."$(getprop ro.product.cpu.abi)" sepatch -ST
+cp /sys/fs/selinux/policy "${log_dir}"/sepolicy.patched
 
 header Updating seapp_contexts
 

--- a/app/module/service.sh
+++ b/app/module/service.sh
@@ -1,12 +1,20 @@
 # SPDX-FileCopyrightText: 2024 Andrew Gunnerson
 # SPDX-License-Identifier: GPL-3.0-only
 
-source "${0%/*}/boot_common.sh" /data/local/tmp/msd.service.log
+source "${0%/*}/boot_common.sh" /data/local/tmp/msd/service.log
 
 header Starting daemon
 
 # Full path because Magisk runs this script in busybox's standalone ash mode and
 # we need Android's toybox version of runcon.
-exec /system/bin/runcon u:r:msd_daemon:s0 \
+/system/bin/runcon u:r:msd_daemon:s0 \
     "${mod_dir}"/msd-tool."$(getprop ro.product.cpu.abi)" \
-        daemon --log-target logcat --log-level debug
+        daemon --log-target logcat --log-level debug &
+
+sleep 1
+
+ps -efZ > "${log_dir}"/ps.log
+
+dmesg > "${log_dir}"/dmesg.log
+
+logcat -s msd-tool > "${log_dir}"/msd-tool.log

--- a/msd-tool/src/main.rs
+++ b/msd-tool/src/main.rs
@@ -11,11 +11,11 @@ mod util;
 use std::{
     fmt,
     io::{self, IsTerminal},
+    process::ExitCode,
 };
 
-use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
-use tracing::Level;
+use tracing::{error, Level};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Subcommand)]
@@ -87,14 +87,22 @@ fn init_logging(target: LogTarget, level: Level) {
     }
 }
 
-fn main() -> Result<()> {
+fn main() -> ExitCode {
     let cli = Cli::parse();
 
     init_logging(cli.log_target, cli.log_level);
 
-    match cli.command {
+    let ret = match cli.command {
         Command::Client(c) => client::subcommand_client(&c),
         Command::Daemon(c) => daemon::subcommand_daemon(&c),
         Command::Sepatch(c) => sepatch::subcommand_sepatch(&c),
+    };
+
+    match ret {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            error!("{e:?}");
+            ExitCode::FAILURE
+        }
     }
 }


### PR DESCRIPTION
This will dump the SELinux policies before and after patching and also the kernel and daemon logs.