### PR TITLE
msd-tool: Add support for devices without gadget HAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ MSD is installed as a Magisk/KernelSU module so that it can run with system app 
   * To check, run `ls /config/usb_gadget/g1` as root.
 * The device's kernel must be compiled with support for the mass storage USB gadget
   * To check, run `zcat /proc/config.gz | grep CONFIG_USB_CONFIGFS_MASS_STORAGE` as root.
-* The device must use Android's USB gadget HAL
-  * To check, run `pgrep -f android.hardware.usb.gadget-service` as root.
 * Only local files are supported
   * Android's Storage Access Framework allows cloud providers to present a file as a local file using FUSE (specifically, via `StorageManager.openProxyFileDescriptor`). Unfortunately, even for the few cloud providers that support this, these files cannot be used because Android's implementation of this mechanism does not allow files to be reopened. Setting up a mass storage device requires reopening the file because the kernel has no way to accept an already open file descriptor.
 

--- a/msd-tool/src/daemon.rs
+++ b/msd-tool/src/daemon.rs
@@ -175,7 +175,7 @@ fn handle_set_mass_storage_request(request: &SetMassStorageRequest) -> Result<()
         .collect::<io::Result<Vec<_>>>()
         .context("Failed to search for gadget HAL process")?;
     if gadget_hal_stoppers.is_empty() {
-        bail!("Failed to find gadget HAL process: {GADGET_HAL_PROCESS}*");
+        warn!("No gadget HAL process found: {GADGET_HAL_PROCESS}*");
     }
 
     let Some(controller) = usb_controller()? else {

--- a/msd-tool/src/sepatch.rs
+++ b/msd-tool/src/sepatch.rs
@@ -162,6 +162,7 @@ pub fn subcommand_sepatch(cli: &SepatchCli) -> Result<()> {
     let c_lnk_file = c!("lnk_file")?;
     let p_lnk_file_create = p!(c_lnk_file, "create")?;
     let p_lnk_file_read = p!(c_lnk_file, "read")?;
+    let p_lnk_file_setattr = p!(c_lnk_file, "setattr")?;
     let p_lnk_file_unlink = p!(c_lnk_file, "unlink")?;
 
     let c_process = c!("process")?;
@@ -335,7 +336,12 @@ pub fn subcommand_sepatch(cli: &SepatchCli) -> Result<()> {
     ] {
         pdb.set_rule(t_daemon, t_configfs, c_file, perm, RuleAction::Allow);
     }
-    for perm in [p_lnk_file_create, p_lnk_file_read, p_lnk_file_unlink] {
+    for perm in [
+        p_lnk_file_create,
+        p_lnk_file_read,
+        p_lnk_file_setattr,
+        p_lnk_file_unlink,
+    ] {
         pdb.set_rule(t_daemon, t_configfs, c_lnk_file, perm, RuleAction::Allow);
     }
 


### PR DESCRIPTION
Older devices use init scripts for managing the USB controller and they don't have any process running that constantly tries to ensure that the USB controller state is correct.

On these devices, we can skip sending SIGSTOP/SIGCONT, but we might need to chown the configfs directory since it could be owned by root.

Fixes: #19