### PR TITLE
Move plat_seapp_contexts patching to its own module

### DIFF
--- a/app/module/customize.sh
+++ b/app/module/customize.sh
@@ -11,12 +11,6 @@ run() {
         echo "Failed to chmod msd-tool" 2>&1
         return 1
     fi
-
-    # https://github.com/HuskyDG/magic_overlayfs/blob/e5e6087d206f4fa4ed24683484c3df93eb258c27/magisk-module/customize.sh#L130
-    if [ "$KSU" == true ]; then
-        ui_print "- Running on KernelSU. SELinux policy will be patched in post-mount"
-        mv -f "$MODPATH/post-fs-data.sh" "$MODPATH/post-mount.sh"
-    fi
 }
 
 if ! run 2>&1; then

--- a/app/module/patch-plat_seapp_contexts.sh
+++ b/app/module/patch-plat_seapp_contexts.sh
@@ -3,16 +3,6 @@
 
 source "${0%/*}/boot_common.sh" /data/local/tmp/msd/post-fs-data.log
 
-# toybox's `mountpoint` command only works for directories, but bind mounts can
-# be files too.
-has_mountpoint() {
-    local mnt=${1}
-
-    awk -v "mnt=${mnt}" \
-        'BEGIN { ret=1 } $5 == mnt { ret=0; exit } END { exit ret }' \
-        /proc/self/mountinfo
-}
-
 header Patching SELinux policy
 
 cp /sys/fs/selinux/policy "${log_dir}"/sepolicy.orig
@@ -21,29 +11,9 @@ cp /sys/fs/selinux/policy "${log_dir}"/sepolicy.patched
 
 header Updating seapp_contexts
 
-seapp_file=/system/etc/selinux/plat_seapp_contexts
-seapp_temp_dir=${mod_dir}/seapp_temp
-seapp_temp_file=${mod_dir}/seapp_temp/plat_seapp_contexts
-
-mkdir -p "${seapp_temp_dir}"
-
-nsenter --mount=/proc/1/ns/mnt -- \
-    mount -t tmpfs "${app_id}" "${seapp_temp_dir}"
-
-# Full path because Magisk runs this script in busybox's standalone ash mode and
-# we need Android's toybox version of cp.
-/system/bin/cp --preserve=a "${seapp_file}" "${seapp_temp_file}"
-
-cat >> "${seapp_temp_file}" << EOF
+cat >> "${1}" << EOF
 user=_app isPrivApp=true name=${app_id} domain=msd_app type=app_data_file levelFrom=all
 EOF
-
-while has_mountpoint "${seapp_file}"; do
-    umount -l "${seapp_file}"
-done
-
-nsenter --mount=/proc/1/ns/mnt -- \
-    mount -o ro,bind "${seapp_temp_file}" "${seapp_file}"
 
 # On some devices, the system time is set too late in the boot process. This,
 # for some reason, causes the package manager service to not update the package


### PR DESCRIPTION
I think this is a better solution to #17 since this prevents conflicts between modules and is more stealthy on KernelSU (no mount abnormalities as per Momo).

The module is [here](https://github.com/fnr1r/plat_seapp_patcher). I'm open to feedback and willing to make any changes to the module mentioned above.