### PR TITLE
post-fs-data.sh: Combine seapp snippets from all modules to produce full file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -295,6 +295,24 @@ android.applicationVariants.all {
         }
     }
 
+    val seappContexts = tasks.register("seappContexts${capitalized}") {
+        inputs.property("variant.applicationId", variant.applicationId)
+
+        val outputFile = variantDir.map { it.file("plat_seapp_contexts") }
+        outputs.file(outputFile)
+
+        doLast {
+            outputFile.get().asFile.writeText(listOf(
+                "user=_app",
+                "isPrivApp=true",
+                "name=${variant.applicationId}",
+                "domain=msd_app",
+                "type=app_data_file",
+                "levelFrom=all",
+            ).joinToString(" "))
+        }
+    }
+
     tasks.register<Zip>("zip${capitalized}") {
         inputs.property("rootProject.name", rootProject.name)
         inputs.property("variant.applicationId", variant.applicationId)
@@ -312,6 +330,7 @@ android.applicationVariants.all {
         dependsOn.add(variant.assembleProvider)
 
         from(moduleProp.map { it.outputs })
+        from(seappContexts.map { it.outputs })
         from(variant.outputs.map { it.outputFile }) {
             into("system/priv-app/${variant.applicationId}")
         }

--- a/app/module/customize.sh
+++ b/app/module/customize.sh
@@ -11,12 +11,6 @@ run() {
         echo "Failed to chmod msd-tool" 2>&1
         return 1
     fi
-
-    # https://github.com/HuskyDG/magic_overlayfs/blob/e5e6087d206f4fa4ed24683484c3df93eb258c27/magisk-module/customize.sh#L130
-    if [ "$KSU" == true ]; then
-        ui_print "- Running on KernelSU. SELinux policy will be patched in post-mount"
-        mv -f "$MODPATH/post-fs-data.sh" "$MODPATH/post-mount.sh"
-    fi
 }
 
 if ! run 2>&1; then

--- a/app/module/post-fs-data.sh
+++ b/app/module/post-fs-data.sh
@@ -3,47 +3,28 @@
 
 source "${0%/*}/boot_common.sh" /data/local/tmp/msd/post-fs-data.log
 
-# toybox's `mountpoint` command only works for directories, but bind mounts can
-# be files too.
-has_mountpoint() {
-    local mnt=${1}
-
-    awk -v "mnt=${mnt}" \
-        'BEGIN { ret=1 } $5 == mnt { ret=0; exit } END { exit ret }' \
-        /proc/self/mountinfo
-}
-
 header Patching SELinux policy
 
 cp /sys/fs/selinux/policy "${log_dir}"/sepolicy.orig
 "${mod_dir}"/msd-tool."$(getprop ro.product.cpu.abi)" sepatch -ST
 cp /sys/fs/selinux/policy "${log_dir}"/sepolicy.patched
 
+# Android's SELinux implementation cannot load seapp_contexts files from a
+# directory, so the original file must be edited and multiple modules may want
+# to do so. Due to Magisk/KernelSU's behavior of running scripts for all modules
+# before mounting any files, each module that modifies this file needs to
+# produce the same output, so snippets from all modules are included.
+# Regardless of the module load order, all modules that include the following
+# command will produce the same output file, so it does not matter which one is
+# mounted last.
+
 header Updating seapp_contexts
 
-seapp_file=/system/etc/selinux/plat_seapp_contexts
-seapp_temp_dir=${mod_dir}/seapp_temp
-seapp_temp_file=${mod_dir}/seapp_temp/plat_seapp_contexts
-
-mkdir -p "${seapp_temp_dir}"
-
-nsenter --mount=/proc/1/ns/mnt -- \
-    mount -t tmpfs "${app_id}" "${seapp_temp_dir}"
-
-# Full path because Magisk runs this script in busybox's standalone ash mode and
-# we need Android's toybox version of cp.
-/system/bin/cp --preserve=a "${seapp_file}" "${seapp_temp_file}"
-
-cat >> "${seapp_temp_file}" << EOF
-user=_app isPrivApp=true name=${app_id} domain=msd_app type=app_data_file levelFrom=all
-EOF
-
-while has_mountpoint "${seapp_file}"; do
-    umount -l "${seapp_file}"
-done
-
-nsenter --mount=/proc/1/ns/mnt -- \
-    mount -o ro,bind "${seapp_temp_file}" "${seapp_file}"
+mkdir -p "${mod_dir}/system/etc/selinux"
+paste -s -d '\n' \
+    /system/etc/selinux/plat_seapp_contexts \
+    /data/adb/modules/*/plat_seapp_contexts \
+    > "${mod_dir}/system/etc/selinux/plat_seapp_contexts"
 
 # On some devices, the system time is set too late in the boot process. This,
 # for some reason, causes the package manager service to not update the package


### PR DESCRIPTION
This is more reliable and has better compatibility than trying to mount things ourselves. Any module that modifies plat_seapp_contents and includes the same command will produce the same output file, so the order that Magisk/KernelSU loads and mounts modules does not matter. Currently, MSD and Custota are the only two modules known to modify this file.

See: #25
Issue: #17
Issue: #21
Custota version of this PR: https://github.com/chenxiaolong/Custota/pull/99