### PR TITLE
Show local path instead of URI where possible

### DIFF
--- a/app/src/main/java/com/chiller3/msd/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/msd/settings/SettingsFragment.kt
@@ -376,7 +376,7 @@ class SettingsFragment : PreferenceFragmentCompat(), FragmentResultListener,
                     DeviceType.DISK_RO -> getString(R.string.pref_device_name_disk_ro)
                     DeviceType.DISK_RW -> getString(R.string.pref_device_name_disk_rw)
                 }
-                summary = device.uri.formattedString
+                summary = device.localPath ?: device.uri.formattedString
                 isIconSpaceReserved = false
                 isPersistent = false
                 isChecked = device.enabled


### PR DESCRIPTION
Not every document provider includes a path in the URI, which makes it impossible to distinguish between multiple devices. Since mass storage device emulation can only work with local files, we can try to show the local path instead. If the file is no longer accessible (eg. due to it being deleted), the UI will fall back to the current behavior of showing the URI.

Fixes: #28