### PR TITLE
msd-tool: Unconditionally chown usb_gadget directory

### DIFF
--- a/msd-tool/src/usb.rs
+++ b/msd-tool/src/usb.rs
@@ -15,7 +15,7 @@ use std::{
 use anyhow::{anyhow, bail, Context, Result};
 use cap_std::{ambient_authority, fs::Dir};
 use rustix::{
-    fs::{Access, AtFlags, Gid, Uid},
+    fs::{AtFlags, Gid, Uid},
     io::Errno,
 };
 
@@ -138,12 +138,10 @@ impl UsbGadget {
         let name = Path::new(name);
         let parent = open_configfs_dir(parent_path)?;
 
-        if rustix::fs::accessat(&parent, name, Access::WRITE_OK, AtFlags::empty()).is_err() {
-            // Older devices without the gadget HAL might leave the files owned
-            // by root because the USB config switching is done by init scripts
-            // that have root privileges.
-            chown_configfs_dir_to_rugid(parent_path, &parent, name)?;
-        }
+        // Older devices without the gadget HAL might leave the files owned by
+        // root because the USB config switching is done by init scripts that
+        // have root privileges.
+        chown_configfs_dir_to_rugid(parent_path, &parent, name)?;
 
         let dir = open_configfs_rel_dir(parent_path, &parent, name)?;
 


### PR DESCRIPTION
This was previously done conditionally out of an abundance of caution in case some other process depends on the permissions not changing. There have been a number of cases where MSD's heuristic of when to chown isn't sufficient on real world devices, so let's just always chown.

In practice, there are only ever two situations:

* the USB gadget is managed by Android's USB gadget HAL, which runs as the `system` user
* the USB gadget is managed by init scripts, which run as `root`

Making everything owned by `system` should not break either scenario.

Fixes: #36