### PR TITLE
Reduce minimum API level to 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MSD is installed as a Magisk/KernelSU module so that it can run with system app 
 
 ## Features
 
-* Supports Android 13 and newer
+* Supports Android 11 and newer
 * Supports emulating multiple mass storage devices at the same time
   * Including mixing and matching CD-ROM and disk devices
 * Does not interfere with ADB, MTP, or any other normal USB functionality

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,7 @@ android {
 
     defaultConfig {
         applicationId = "com.chiller3.msd"
-        minSdk = 33
+        minSdk = 30
         targetSdk = 35
         versionCode = gitVersionCode
         versionName = gitVersionName

--- a/app/module/update-binary
+++ b/app/module/update-binary
@@ -22,9 +22,9 @@ else
     # Installing via Magisk Manager.
 
     api_ver=$(getprop ro.build.version.sdk)
-    if [ "${api_ver}" -lt 33 ]; then
+    if [ "${api_ver}" -lt 30 ]; then
         ui_print 'The Android version on this device is too old'
-        ui_print 'Required: SDK >=33 (Android >=13)'
+        ui_print 'Required: SDK >=30 (Android >=11)'
         ui_print "Current: SDK ${api_ver}"
         exit 1
     fi

--- a/app/src/main/java/com/chiller3/msd/dialog/DeviceDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/msd/dialog/DeviceDialogFragment.kt
@@ -10,6 +10,7 @@ import android.content.DialogInterface
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
@@ -50,7 +51,7 @@ open class DeviceDialogFragment : DialogFragment() {
     data class RemoveDevice(val uri: Uri) : Action
 
     private val device by lazy {
-        requireArguments().getParcelable(ARG_DEVICE, DeviceInfo::class.java)
+        BundleCompat.getParcelable(requireArguments(), ARG_DEVICE, DeviceInfo::class.java)
     }
     private val items by lazy {
         mutableListOf<Pair<Action, String>>().apply {

--- a/app/src/main/java/com/chiller3/msd/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/msd/settings/SettingsFragment.kt
@@ -13,6 +13,7 @@ import android.os.Parcelable
 import android.provider.DocumentsContract
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.os.BundleCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
@@ -126,8 +127,10 @@ class SettingsFragment : PreferenceFragmentCompat(), FragmentResultListener,
         setPreferencesFromResource(R.xml.preferences_root, rootKey)
 
         if (savedInstanceState != null) {
-            partialState = savedInstanceState.getParcelable(
-                KEY_PARTIAL_STATE, PartialState::class.java
+            partialState = BundleCompat.getParcelable(
+                savedInstanceState,
+                KEY_PARTIAL_STATE,
+                PartialState::class.java,
             )
         }
 
@@ -206,8 +209,11 @@ class SettingsFragment : PreferenceFragmentCompat(), FragmentResultListener,
 
         when (requestKey) {
             DeviceDialogFragment.TAG -> {
-                val action = result.getParcelable(DeviceDialogFragment.RESULT_ACTION,
-                    DeviceDialogFragment.Action::class.java)
+                val action = BundleCompat.getParcelable(
+                    result,
+                    DeviceDialogFragment.RESULT_ACTION,
+                    DeviceDialogFragment.Action::class.java,
+                )
 
                 when (action) {
                     is DeviceDialogFragment.AddDevice -> {

--- a/msd-tool/src/daemon.rs
+++ b/msd-tool/src/daemon.rs
@@ -370,7 +370,7 @@ pub fn subcommand_daemon(_cli: &DaemonCli) -> Result<()> {
                 info!("Received connection");
 
                 if let Err(e) = handle_client(stream) {
-                    error!("Thread failed: {e}");
+                    error!("Thread failed: {e:?}");
                 }
             });
         }


### PR DESCRIPTION
The biggest changes are for the SELinux policy:
    
* `sys.usb.controller` is labeled as `exported2_system_prop`
* `userfaultfd` types do not exist
* `com.android.externalstorage.documents` file descriptors are labeled as `platform_app`

Closes: #39