### PR TITLE
Add support for resizing writable disk images

### DIFF
--- a/app/src/main/java/com/chiller3/msd/dialog/DeviceDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/msd/dialog/DeviceDialogFragment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -15,8 +15,8 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
 import com.chiller3.msd.R
-import com.chiller3.msd.settings.DeviceInfo
 import com.chiller3.msd.settings.DeviceType
+import com.chiller3.msd.settings.UiDeviceInfo
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.parcelize.Parcelize
 
@@ -27,7 +27,7 @@ open class DeviceDialogFragment : DialogFragment() {
         private const val ARG_DEVICE = "device"
         const val RESULT_ACTION = "action"
 
-        fun newInstance(device: DeviceInfo?): DeviceDialogFragment =
+        fun newInstance(device: UiDeviceInfo?): DeviceDialogFragment =
             DeviceDialogFragment().apply {
                 arguments = bundleOf(
                     ARG_DEVICE to device,
@@ -48,10 +48,13 @@ open class DeviceDialogFragment : DialogFragment() {
     data object CreateDevice : Action
 
     @Parcelize
+    data class ResizeDevice(val uri: Uri, val existingSize: Long) : Action
+
+    @Parcelize
     data class RemoveDevice(val uri: Uri) : Action
 
     private val device by lazy {
-        BundleCompat.getParcelable(requireArguments(), ARG_DEVICE, DeviceInfo::class.java)
+        BundleCompat.getParcelable(requireArguments(), ARG_DEVICE, UiDeviceInfo::class.java)
     }
     private val items by lazy {
         mutableListOf<Pair<Action, String>>().apply {
@@ -69,6 +72,9 @@ open class DeviceDialogFragment : DialogFragment() {
                 if (device.type != DeviceType.DISK_RW) {
                     add(ChangeDevice(device.uri, DeviceType.DISK_RW) to
                             getString(R.string.dialog_device_switch_disk_rw))
+                } else if (device.size != null) {
+                    add(ResizeDevice(device.uri, device.size) to
+                            getString(R.string.dialog_device_resize_disk_rw))
                 }
                 add(RemoveDevice(device.uri) to getString(R.string.dialog_device_delete))
             } else {

--- a/app/src/main/java/com/chiller3/msd/dialog/ImageSizeDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/msd/dialog/ImageSizeDialogFragment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -7,9 +7,13 @@ package com.chiller3.msd.dialog
 
 import android.app.Dialog
 import android.content.DialogInterface
+import android.net.Uri
 import android.os.Bundle
+import android.os.Parcelable
 import android.text.InputType
+import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.DialogFragment
@@ -17,25 +21,66 @@ import androidx.fragment.app.setFragmentResult
 import com.chiller3.msd.R
 import com.chiller3.msd.databinding.ImageSizeDialogBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.parcelize.Parcelize
 import java.util.regex.Pattern
 
 class ImageSizeDialogFragment : DialogFragment() {
     companion object {
         val TAG: String = ImageSizeDialogFragment::class.java.simpleName
 
-        const val RESULT_SIZE = "size"
+        private const val ARG_URI = "uri"
+        private const val ARG_EXISTING_SIZE = "existing_size"
+        const val RESULT_ACTION = "action"
 
         private val REGEX_SIZE =
             Pattern.compile("^(\\d+)\\s*((?:[GMK]i?)?B)?$", Pattern.CASE_INSENSITIVE)
+
+        fun newForCreate() = ImageSizeDialogFragment().apply {
+            arguments = bundleOf()
+        }
+
+        fun newForResize(uri: Uri, existingSize: Long) = ImageSizeDialogFragment().apply {
+            arguments = bundleOf(
+                ARG_URI to uri,
+                ARG_EXISTING_SIZE to existingSize,
+            )
+        }
     }
 
+    @Parcelize
+    sealed interface Action : Parcelable
+
+    @Parcelize
+    data class CreateImage(val size: Long) : Action
+
+    @Parcelize
+    data class ResizeImage(val uri: Uri, val size: Long) : Action
+
+    private val uri by lazy {
+        BundleCompat.getParcelable(requireArguments(), ARG_URI, Uri::class.java)
+    }
     private lateinit var binding: ImageSizeDialogBinding
     private var size: Long? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        // We shouldn't be able to open the dialog if the size of the image is unknown, but if that
+        // somehow happens anyway, make (nearly) every value the user enters show a warning.
+        val arguments = requireArguments()
+        require((uri != null) == arguments.containsKey(ARG_EXISTING_SIZE))
+        val existingSize = arguments.getLong(ARG_EXISTING_SIZE, 0)
+
         binding = ImageSizeDialogBinding.inflate(layoutInflater)
 
-        binding.message.setText(R.string.dialog_image_size_message)
+        binding.message.text = buildString {
+            if (uri == null) {
+                append(getString(R.string.dialog_image_size_create_message))
+            } else {
+                append(getString(R.string.dialog_image_size_resize_message, existingSize))
+            }
+
+            append("\n\n")
+            append(getString(R.string.dialog_image_size_units_message))
+        }
 
         binding.text.inputType = InputType.TYPE_CLASS_TEXT or
                 InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
@@ -51,7 +96,7 @@ class ImageSizeDialogFragment : DialogFragment() {
 
                 val number = try {
                     matcher.group(1)!!.toLong()
-                } catch (e: NumberFormatException) {
+                } catch (_: NumberFormatException) {
                     return@addTextChangedListener
                 }
                 val multiplier = when (val suffix = matcher.group(2)?.lowercase()) {
@@ -69,8 +114,24 @@ class ImageSizeDialogFragment : DialogFragment() {
                     return@addTextChangedListener
                 }
 
-                size = number * multiplier
-                binding.textLayout.helperText = "$size B"
+                val newSize = number * multiplier
+
+                if (newSize < existingSize) {
+                    binding.textLayout.error =
+                        getString(R.string.dialog_image_size_truncate_warning)
+                } else {
+                    binding.textLayout.error = null
+                    // Don't keep the layout space for the error message reserved.
+                    binding.textLayout.isErrorEnabled = false
+                }
+
+                size = newSize
+                binding.textLayout.suffixText =
+                    if (binding.textLayout.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+                        "$size B ="
+                    } else {
+                        "= $size B"
+                    }
             } finally {
                 refreshOkButtonEnabledState()
             }
@@ -97,7 +158,11 @@ class ImageSizeDialogFragment : DialogFragment() {
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
 
-        setFragmentResult(tag!!, bundleOf(RESULT_SIZE to size))
+        val action = size?.let { size ->
+            uri?.let { ResizeImage(it, size) } ?: CreateImage(size)
+        }
+
+        setFragmentResult(tag!!, bundleOf(RESULT_ACTION to action))
     }
 
     private fun refreshOkButtonEnabledState() {

--- a/app/src/main/java/com/chiller3/msd/settings/DeviceInfo.kt
+++ b/app/src/main/java/com/chiller3/msd/settings/DeviceInfo.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -37,7 +37,7 @@ data class DeviceInfo(
             val type = try {
                 DeviceType.valueOf(rawType)
             } catch (e: IllegalArgumentException) {
-                Log.w(TAG, "Invalid device type: $rawType")
+                Log.w(TAG, "Invalid device type: $rawType", e)
                 return null
             }
 
@@ -50,3 +50,12 @@ data class DeviceInfo(
         editor.putString(prefix + PREF_SUFFIX_TYPE, type.toString())
     }
 }
+
+@Parcelize
+data class UiDeviceInfo(
+    val uri: Uri,
+    val localPath: String?,
+    val type: DeviceType,
+    val enabled: Boolean,
+    val size: Long?,
+) : Parcelable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <resources>
@@ -38,6 +38,7 @@
     <string name="alert_not_local_file">Failed to add image because it is not a local file.</string>
     <string name="alert_not_local_file_details">The image could not be added because it is not a local file. Even if the third party app goes through the effort to provide a file descriptor supporting random access, Android\'s limitations on reopening files prevents it from being used.</string>
     <string name="alert_create_image_failure">Failed to create new writable disk image.</string>
+    <string name="alert_resize_image_failure">Failed to resize writable disk image.</string>
 
     <!-- Add device dialog -->
     <string name="dialog_device_title_add">Add new device</string>
@@ -46,6 +47,7 @@
     <string name="dialog_device_add_disk_ro">Add existing read-only disk image</string>
     <string name="dialog_device_add_disk_rw">Add existing writable disk image</string>
     <string name="dialog_device_create_disk_rw">Create new writable disk image</string>
+    <string name="dialog_device_resize_disk_rw">Resize writable disk image</string>
     <string name="dialog_device_switch_cdrom">Switch to CD-ROM</string>
     <string name="dialog_device_switch_disk_ro">Switch to read-only disk</string>
     <string name="dialog_device_switch_disk_rw">Switch to writable disk</string>
@@ -53,5 +55,8 @@
 
     <!-- Image size dialog -->
     <string name="dialog_image_size_title">Image size</string>
-    <string name="dialog_image_size_message">The image will be created as a sparse file. The image will start consuming space on disk only after data is written to it.\n\nBoth IEC (KiB/MiB/GiB) and SI (KB/MB/GB) suffixes are supported.</string>
+    <string name="dialog_image_size_create_message">The image will be created as a sparse file. The image will start consuming space on disk only after data is written to it.</string>
+    <string name="dialog_image_size_resize_message">Resize the existing image from %1$d B. Note that this does not change the contents of the image. It will need to be manually repartitioned to make use of any extra space.</string>
+    <string name="dialog_image_size_units_message">Both IEC (KiB/MiB/GiB) and SI (KB/MB/GB) suffixes are supported.</string>
+    <string name="dialog_image_size_truncate_warning">This is smaller than the original size. Truncating the image may lead to data loss.</string>
 </resources>


### PR DESCRIPTION
This only changes the size of the image file. The user is responsible for manually repartitioning the contents if needed.

Fixes: #42