### PR TITLE
Add support for Samsung (and other Qualcomm) devices

### DIFF
--- a/msd-tool/src/sepatch.rs
+++ b/msd-tool/src/sepatch.rs
@@ -342,36 +342,43 @@ pub fn subcommand_sepatch(cli: &SepatchCli) -> Result<()> {
     }
 
     // Allow the daemon to interact with configfs.
-    for perm in [
-        p_dir_add_name,
-        p_dir_create,
-        p_dir_open,
-        p_dir_read,
-        p_dir_remove_name,
-        p_dir_rmdir,
-        p_dir_search,
-        p_dir_setattr,
-        p_dir_write,
-    ] {
-        pdb.set_rule(t_daemon, t_configfs, c_dir, perm, RuleAction::Allow);
+    let mut configfs_types = vec![t_configfs];
+    // This is used on Samsung stock OS.
+    if let Some(target) = pdb.get_type_id("usb_configfs") {
+        configfs_types.push(target);
     }
-    for perm in [
-        p_file_create,
-        p_file_getattr,
-        p_file_open,
-        p_file_read,
-        p_file_setattr,
-        p_file_write,
-    ] {
-        pdb.set_rule(t_daemon, t_configfs, c_file, perm, RuleAction::Allow);
-    }
-    for perm in [
-        p_lnk_file_create,
-        p_lnk_file_read,
-        p_lnk_file_setattr,
-        p_lnk_file_unlink,
-    ] {
-        pdb.set_rule(t_daemon, t_configfs, c_lnk_file, perm, RuleAction::Allow);
+    for target in configfs_types {
+        for perm in [
+            p_dir_add_name,
+            p_dir_create,
+            p_dir_open,
+            p_dir_read,
+            p_dir_remove_name,
+            p_dir_rmdir,
+            p_dir_search,
+            p_dir_setattr,
+            p_dir_write,
+        ] {
+            pdb.set_rule(t_daemon, target, c_dir, perm, RuleAction::Allow);
+        }
+        for perm in [
+            p_file_create,
+            p_file_getattr,
+            p_file_open,
+            p_file_read,
+            p_file_setattr,
+            p_file_write,
+        ] {
+            pdb.set_rule(t_daemon, target, c_file, perm, RuleAction::Allow);
+        }
+        for perm in [
+            p_lnk_file_create,
+            p_lnk_file_read,
+            p_lnk_file_setattr,
+            p_lnk_file_unlink,
+        ] {
+            pdb.set_rule(t_daemon, target, c_lnk_file, perm, RuleAction::Allow);
+        }
     }
 
     // Allow the daemon to read the external_storage.sdcardfs.enabled and


### PR DESCRIPTION
These devices ship with `/vendor/etc/init/hw/init.qcom.usb.rc` that pre-create a mass_storage.0 function. Unfortunately, there is a kernel bug where trying to create a new mass storage function will fail with:

    sysfs: cannot create duplicate filename '/devices/virtual/android_usb/android0/f_mass_storage'

This happens even if the mass_storage.0 function is deleted first. To work around this, the daemon will now reuse the existing function instead of creating a new `mass_storage.msd` function. It will also avoid deleting it and instead, unset LUN 0 and delete all other LUNs.

Furthermore, Samsung's `/sdcard` is owned by GID 9997 (`everybody`), so that's included in the daemon's supplementary groups in addition to the existing GID 1015 (`sdcard_rw`).

`/config/usb_gadget` is also labeled with `usb_configfs` instead of AOSP's `configfs`.

Finally, since we now need to deal with unconfigured, but present, functions, the daemon no longer complains about a missing newline when `<lun>/file` is an empty file.

Fixes: #58
Fixes: #62