### PR TITLE
Fix missing line wrapping for SwitchPreferenceCompat titles

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <resources>
     <style name="SwitchPreferenceCompat.Material3" parent="Preference.SwitchPreferenceCompat.Material">
         <item name="android:widgetLayout">@layout/material_switch_preference</item>
+        <!--
+            The androidx preference library sets this for Preference.Material and
+            Preference.SwitchPreference.Material, but forgot to do so for SwitchPreferenceCompat.
+        -->
+        <item name="singleLineTitle">false</item>
     </style>
 
-    <style name="SplitSwitchPreference.Material3" parent="Preference.SwitchPreferenceCompat.Material">
+    <style name="SplitSwitchPreference.Material3" parent="SwitchPreferenceCompat.Material3">
         <item name="android:widgetLayout">@layout/split_switch_preference</item>
     </style>
 </resources>


### PR DESCRIPTION
The androidx preference library sets `singleLineTitle` to false for `Preference` and `SwitchPreference`, but it looks like they forgot to do so for `SwitchPreferenceCompat`.