### PR TITLE
Minor fixes to Compose UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,7 +163,6 @@ android {
     buildFeatures {
         buildConfig = true
         compose = true
-        viewBinding = true
     }
     lint {
         // The translations are always going to lag behind new strings being

--- a/app/src/main/java/com/chiller3/msd/settings/ErrorDetailsDialog.kt
+++ b/app/src/main/java/com/chiller3/msd/settings/ErrorDetailsDialog.kt
@@ -9,6 +9,7 @@ package com.chiller3.msd.settings
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
@@ -33,7 +34,9 @@ fun ErrorDetailsDialog(
         },
         text = {
             message?.let {
-                Text(text = it)
+                SelectionContainer {
+                    Text(text = it)
+                }
             }
         },
         onDismissRequest = onDismiss,

--- a/app/src/main/java/com/chiller3/msd/settings/ImageSizeDialog.kt
+++ b/app/src/main/java/com/chiller3/msd/settings/ImageSizeDialog.kt
@@ -12,16 +12,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
@@ -57,8 +55,8 @@ fun ImageSizeDialog(
     onSelect: (ImageSizeResult) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var input by rememberSaveable { mutableStateOf("") }
-    val parsed = tryParseInput(input, action)
+    val input = rememberTextFieldState()
+    val parsed = tryParseInput(input.text.toString(), action)
 
     AlertDialog(
         title = { Text(text = stringResource(R.string.dialog_image_size_title)) },
@@ -67,9 +65,8 @@ fun ImageSizeDialog(
                 Text(text = buildMessage(action))
 
                 OutlinedTextField(
+                    state = input,
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                    value = input,
-                    onValueChange = { input = it },
                     suffix = {
                         if (parsed is ImageSizeParse.Value) {
                             Text(text = parsed.suffix)
@@ -85,6 +82,7 @@ fun ImageSizeDialog(
                         capitalization = KeyboardCapitalization.None,
                         autoCorrectEnabled = false,
                     ),
+                    lineLimits = TextFieldLineLimits.SingleLine,
                 )
             }
         },

--- a/app/src/main/java/com/chiller3/msd/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/msd/ui/Screen.kt
@@ -45,8 +45,8 @@ fun AppScreen(
         },
         containerColor = PreferenceDefaults.containerColor,
     ) { contentPadding ->
-        val outerPadding = contentPadding.copy(bottom = 0.dp)
-        val innerPadding = contentPadding.copy(start = 0.dp, top = 0.dp, end = 0.dp)
+        val outerPadding = contentPadding.copy(start = 0.dp, end = 0.dp, bottom = 0.dp)
+        val innerPadding = contentPadding.copy(top = 0.dp)
 
         Box(modifier = Modifier.padding(outerPadding)) {
             content(AppScreenParams(


### PR DESCRIPTION
- Adjust window insets to allow scrolling from inset region
- Make error dialog text selectable
- Use `TextFieldState` for all `TextField`s
- Remove viewbinding generation now that we don't use views