### PR TITLE
msd-tool/daemon: Remove sdcardfs check for supplemental groups

### DIFF
--- a/app/module/service.sh
+++ b/app/module/service.sh
@@ -27,6 +27,10 @@ ps -efZ > "${log_dir}"/ps.log
 
 cp /proc/self/mountinfo "${log_dir}"/mountinfo.log
 
+cp /proc/filesystems "${log_dir}"/filesystems.log
+
+getprop > "${log_dir}"/properties.log
+
 /system/bin/dmesg -w | grep avc: > "${log_dir}"/audit.log &
 
 logcat -s msd-tool > "${log_dir}"/msd-tool.log &

--- a/msd-tool/src/daemon.rs
+++ b/msd-tool/src/daemon.rs
@@ -108,34 +108,6 @@ fn usb_controller() -> Result<Option<String>> {
     Ok(None)
 }
 
-#[cfg(target_os = "android")]
-fn is_sdcardfs() -> Result<bool> {
-    const PROPERTY: &str = "external_storage.sdcardfs.enabled";
-
-    // We may need to change this in the future when Android finally drops
-    // support for sdcardfs in the future.
-    //
-    // https://android.googlesource.com/platform//system/vold/+/f36bdddc7e5545d361ea8fe16cbac315794874e3
-    //
-    // Things we can't do:
-    //
-    // * Parse /proc/self/mountinfo - vold can't mount it until the user unlocks
-    //   the device for the first time, which happens after the daemon is
-    //   already started.
-    //
-    // * Parse /proc/config.gz - The device might not be using sdcardfs even if
-    //   the kernel supports the filesystem. This is the case on some older
-    //   devices running newer custom Android OS builds.
-
-    system_properties::read_bool(PROPERTY, true)
-        .with_context(|| format!("Failed to query property: {PROPERTY}"))
-}
-
-#[cfg(target_os = "linux")]
-fn is_sdcardfs() -> Result<bool> {
-    Ok(false)
-}
-
 /// Find existing mass storage gadget function or return the default.
 ///
 /// Samsung devices have a kernel bug where creating a new mass storage gadget
@@ -405,17 +377,13 @@ fn drop_privileges() -> Result<()> {
     let real_uid = rustix::process::getuid();
     let real_gid = rustix::process::getgid();
 
-    let supplementary_groups: &[Gid] = if is_sdcardfs()? {
-        &[
-            // Android 10 emulator.
-            Gid::from_raw(1015), // sdcard_rw
-            // Samsung.
-            Gid::from_raw(1023), // media_rw
-            Gid::from_raw(9997), // everybody
-        ]
-    } else {
-        &[]
-    };
+    let supplementary_groups = &[
+        // Android 10 emulator with sdcardfs.
+        Gid::from_raw(1015), // sdcard_rw
+        // Samsung with sdcardfs and LineageOS GSI with fuse-bpf.
+        Gid::from_raw(1023), // media_rw
+        Gid::from_raw(9997), // everybody
+    ];
 
     if real_uid == system_uid && real_gid == system_gid {
         let capability_set =


### PR DESCRIPTION
Some esoteric non-sdcardfs setups, like some unofficial LineageOS GSIs, also require the daemon to be in the `media_rw` group.

Fixes: #107